### PR TITLE
TRC selection: remove python code

### DIFF
--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -860,11 +860,11 @@ The certification path of a Control Plane AS certificate starts in a Control Pla
 
 To validate a certification path, a relying party builds a collection of root certificates known as the trust anchor pool. Because TRC updates can introduce a grace period where multiple TRCs overlap, relying parties MUST execute the following steps to determine the correct trust anchor pool for a given verification time:
 
-1. From the set of all available TRCs for the ISD, keep only TRCs whose validity start time (`notBefore` date) is at or before the verification time.
+1. From the set of all available TRCs for the ISD, keep only TRCs whose validity start time (`notBefore` date) is at or before the verification time. If no such TRC exists, the process terminates unsuccessfully.
 
-2. From the remaining TRCs, identify those with the highest base number, then select the TRC with the highest serial number.
+2. From the selected TRCs, identify those with the highest base number (`baseNumber`), then select the TRC among them with the highest serial number (`serialNumber`).
 
-3. If the verification time is strictly greater than the TRC's `notAfter` date, it is no longer valid. There are no valid trust anchors at the verification time, and the process terminates.
+3. If the verification time is strictly greater than the selected TRC's `notAfter` date then the process terminates unsuccessfully.
 
 4. If the TRC is valid, add its root certificates to the trust anchor pool.
 

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -961,36 +961,24 @@ The certification path of a Control Plane AS certificate starts in a Control Pla
 
 However, AS certificates and the corresponding issuing CA certificates are **not** part of the TRC, but are bundled into certificate chains and distributed separately from the corresponding TRC. This separation makes it possible to extend the validity period of the root certificate, and to update the corresponding TRC without having to modify the certificate chain. To be able to validate a certification path, each AS builds a collection of root certificates from the latest TRC of the relevant ISD.
 
-The following section explains how to build a trust anchor pool.
-
 **Note:** Any entity sending information that is secured by the Control Plane PKI, such as control plane messages, MUST be able to provide all the necessary trust material including certificates to verify said information. If any cryptographic material is missing in the process, the relying party MUST query the originator of the message for the missing material through the control plane API described in {{I-D.dekater-scion-controlplane}}, section "Distribution of Cryptographic Material". If it cannot be resolved, the verification process fails. For more details, see 4.2 "Signing and Verifying Control Plane Messages" [](#signing-verifying-cp-messages).
 
 
 ### TRC Selection For Trust Anchor Pool {#trc-selection}
 
-The selection of the right set of TRCs to build the trust anchor pool depends on the time of verification. The trust anchor pool is usually used to verify control plane messages and in this case, the time of verification is the current time. However, if the trust anchor pool will be used for auditing, the time of verification is the point in time to check whether a given signature was verifiable.
+The selection of the right set of TRCs to build the trust anchor pool depends on the time of verification. This is typically the current time when verifying control plane messages.
 
-To construct the trust anchor pool for a specific ISD at a given `verification_time`, a relying party executes the following steps:
+To construct the trust anchor pool for a specific ISD at a given verification time, a relying party executes the following steps:
 
-1. Determine the Active Base Number: Filter the set of all available TRCs for the ISD to those whose `notBefore` validity date is less than or equal to the `verification_time`. From this filtered set, select the highest `baseNumber`.
+1. Filter TRCs whose validity start time (`notBefore`) precedes the verification time.
 
-2. Identify the Candidate TRC: Filter the set of available TRCs again to find only those that match the `baseNumber` identified in Step 1, and whose `notBefore` date is less than or equal to the `verification_time`. From this set, select the TRC with the highest `serialNumber`. This is the *Candidate TRC*.
+2. Filter TRCs with the highest base number, then select the TRC with the highest serial number.
 
-3. Verify Candidate TRC Expiration:**
-   If the `verification_time` is strictly greater than the Candidate TRC's `notAfter` date, the algorithm terminates and returns an empty set. There are no valid trust anchors for this time.
+3. If the TRC is not valid anymore (the verification time is greater than the TRC's `notAfter` date), there are no valid trust anchors at the verification time.
 
-4. Extract Candidate Trust Anchors:**
-   Parse the `certificates` sequence of the Candidate TRC. Extract all certificates that possess a `basicConstraints` extension with the `cA` boolean asserted. Add these CP Root Certificates to the trust anchor pool.
+4. If the TRC is valid, add its root certificates to the trust anchor pool.
 
-5. Evaluate the Grace Period:**
-   Check if the Candidate TRC is currently within its grace period (i.e., `verification_time` <= `notBefore` + `gracePeriod`). If the grace period has expired, the algorithm terminates and returns the current trust anchor pool.
-
-6. Process the Predecessor TRC (If Applicable):
-  If the Candidate TRC is still within its grace period, attempt to retrieve the Predecessor TRC (the TRC with the same `baseNumber` and a `serialNumber` exactly one less than the Candidate TRC).
-   If the Predecessor TRC exists and its `notAfter` date is greater than or equal to the `verification_time`, extract its CP Root Certificates (as described in Step 4) and add them to the trust anchor pool.
-
-7. Return the Pool: The algorithm terminates and returns the assembled trust anchor pool.
-
+5. If the TRC is in its grace period, add the preceding TRC's root certificates to the trust anchor pool.
 
 ## TRC Updates {#update}
 

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -858,7 +858,7 @@ Two TRCs with byte equal payloads can be considered as equal because the TRC pay
 
 The certification path of a Control Plane AS certificate starts in a Control Plane root certificate. While root certificates for a given ISD are distributed via the TRC, AS and issuing CA certificates are distributed separately. This separation makes it possible to extend the validity period of the root certificate, and to update the corresponding TRC without having to modify the certificate chain.
 
-To validate a certification path, a relying party builds a collection of root certificates know as the trust anchor pool. Because TRC updates can introduce a grace period where multiple TRCs overlap, relying parties MUST execute the following steps to determine the correct trust anchor pool for a given verification time:
+To validate a certification path, a relying party builds a collection of root certificates known as the trust anchor pool. Because TRC updates can introduce a grace period where multiple TRCs overlap, relying parties MUST execute the following steps to determine the correct trust anchor pool for a given verification time:
 
 1. From the set of all available TRCs for the ISD, filter out TRCs whose validity start time (`notBefore` date) precedes the verification time.
 

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -860,7 +860,7 @@ The certification path of a Control Plane AS certificate starts in a Control Pla
 
 To validate a certification path, a relying party builds a collection of root certificates known as the trust anchor pool. Because TRC updates can introduce a grace period where multiple TRCs overlap, relying parties MUST execute the following steps to determine the correct trust anchor pool for a given verification time:
 
-1. From the set of all available TRCs for the ISD, filter out TRCs whose validity start time (`notBefore` date) precedes the verification time.
+1. From the set of all available TRCs for the ISD, keep only TRCs whose validity start time (`notBefore` date) is at or before the verification time.
 
 2. From the remaining TRCs, identify those with the highest base number, then select the TRC with the highest serial number.
 

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -970,76 +970,26 @@ The following section explains how to build a trust anchor pool.
 
 The selection of the right set of TRCs to build the trust anchor pool depends on the time of verification. The trust anchor pool is usually used to verify control plane messages and in this case, the time of verification is the current time. However, if the trust anchor pool will be used for auditing, the time of verification is the point in time to check whether a given signature was verifiable.
 
-The selection algorithm for building the trust anchor pool is described in pseudo-python code below.
+To construct the trust anchor pool for a specific ISD at a given `verification_time`, a relying party executes the following steps:
 
-~~~~python
-    def select_trust_anchors(trcs: Dict[(int,int), TRC], \
-    verification_time: int) -> Set[RootCert]:
-        """
-        Args:
-            trcs: The dictionary mapping (serial number, \
-            base number) to the TRC for a given ISD.
-            verification_time: The time of verification.
+1. Determine the Active Base Number: Filter the set of all available TRCs for the ISD to those whose `notBefore` validity date is less than or equal to the `verification_time`. From this filtered set, select the highest `baseNumber`.
 
-        Returns:
-            The set of CP Root certificates acting as trust anchors.
-        """
-        # Find highest base number that has a TRC with validity
-        # period starting before verification time.
-        base_nr = 1
-        for trc in trcs.values()
-            if trc.id.base_nr > base_nr and trc.validity.not_before \
-            <= verification_time:
-                base_nr = trc.id.base_nr
+2. Identify the Candidate TRC: Filter the set of available TRCs again to find only those that match the `baseNumber` identified in Step 1, and whose `notBefore` date is less than or equal to the `verification_time`. From this set, select the TRC with the highest `serialNumber`. This is the *Candidate TRC*.
 
-        # Find TRC with highest serial number with given base number
-        # and a validity period starting before verification time.
-        serial_nr = 1
-        for trc in trcs[isd].values():
-            if trc.id.base_nr != base_nr:
-                continue
-            if trc.id.serial_nr > serial_nr and \
-            trc.validity.not_before <= verification_time:
-                serial_nr = trc.id.serial_nr
+3. Verify Candidate TRC Expiration:**
+   If the `verification_time` is strictly greater than the Candidate TRC's `notAfter` date, the algorithm terminates and returns an empty set. There are no valid trust anchors for this time.
 
-        candidate = trcs[(serial_nr, base_nr)]
+4. Extract Candidate Trust Anchors:**
+   Parse the `certificates` sequence of the Candidate TRC. Extract all certificates that possess a `basicConstraints` extension with the `cA` boolean asserted. Add these CP Root Certificates to the trust anchor pool.
 
-        # If the verification time is not inside the validity period,
-        # there is no valid set of trust anchors.
-        if not candidate.validity.contains(verification_time):
-            return set()
+5. Evaluate the Grace Period:**
+   Check if the Candidate TRC is currently within its grace period (i.e., `verification_time` <= `notBefore` + `gracePeriod`). If the grace period has expired, the algorithm terminates and returns the current trust anchor pool.
 
-        # If the grace period has passed, only the certificates in
-        # that TRC may be used as trust anchors.
-        if candidate.validity.not_before + candidate.grace_period \
-        < verification_time:
-            return collect_trust_anchors(candidate)
+6. Process the Predecessor TRC (If Applicable):
+  If the Candidate TRC is still within its grace period, attempt to retrieve the Predecessor TRC (the TRC with the same `baseNumber` and a `serialNumber` exactly one less than the Candidate TRC).
+   If the Predecessor TRC exists and its `notAfter` date is greater than or equal to the `verification_time`, extract its CP Root Certificates (as described in Step 4) and add them to the trust anchor pool.
 
-        predecessor = trcs.get((serial_nr-1, base_nr))
-        if not predecessor or predecessor.validity.not_after < \
-        verification_time:
-            return collect_trust_anchors(candidate)
-
-        return collect_trust_anchors(candidate) | \
-        collect_trust_anchors(predecessor)
-
-
-    def collect_trust_anchors(trc: TRC) -> Set[RootCert]:
-        """
-        Args:
-            trc: A TRC from which the CP Root Certificates shall \
-            be extracted.
-
-        Returns:
-            The set of CP Root certificates acting as trust anchors.
-        """
-        roots = set()
-        for cert in trc.certificates:
-            if not cert.basic_constraints.ca:
-                continue
-            roots.add(cert)
-        return roots
-~~~~
+7. Return the Pool: The algorithm terminates and returns the assembled trust anchor pool.
 
 
 ## TRC Updates {#update}

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -955,20 +955,11 @@ Two TRCs with byte equal payloads can be considered as equal because the TRC pay
 - The REQUIRED signatures for new certificates are implied by the currently valid TRC payload, and, in case of a TRC update, the predecessor payload.
 
 
-## Certification Path - Trust Anchor Pool
+## Certification Path - Trust Anchor Pool {#trc-selection}
 
-The certification path of a Control Plane AS certificate starts in a Control Plane root certificate. The Control Plane root certificate for a given ISD is distributed via the TRC.
+The certification path of a Control Plane AS certificate starts in a Control Plane root certificate. While root certificates for a given ISD are distributed via the TRC, AS and issuing CA certificates are distributed separately. This separation makes it possible to extend the validity period of the root certificate, and to update the corresponding TRC without having to modify the certificate chain.
 
-However, AS certificates and the corresponding issuing CA certificates are **not** part of the TRC, but are bundled into certificate chains and distributed separately from the corresponding TRC. This separation makes it possible to extend the validity period of the root certificate, and to update the corresponding TRC without having to modify the certificate chain. To be able to validate a certification path, each AS builds a collection of root certificates from the latest TRC of the relevant ISD.
-
-**Note:** Any entity sending information that is secured by the Control Plane PKI, such as control plane messages, MUST be able to provide all the necessary trust material including certificates to verify said information. If any cryptographic material is missing in the process, the relying party MUST query the originator of the message for the missing material through the control plane API described in {{I-D.dekater-scion-controlplane}}, section "Distribution of Cryptographic Material". If it cannot be resolved, the verification process fails. For more details, see 4.2 "Signing and Verifying Control Plane Messages" [](#signing-verifying-cp-messages).
-
-
-### TRC Selection For Trust Anchor Pool {#trc-selection}
-
-The selection of the right set of TRCs to build the trust anchor pool depends on the time of verification. This is typically the current time when verifying control plane messages, but may be a historical point in time when auditing past signatures.
-
-To construct the trust anchor pool for a specific ISD at a given verification time, a relying party MUST execute the following steps:
+To validate a certification path, a relying party builds a collection of root certificates know as the trust anchor pool. Because TRC updates can introduce a grace period where multiple TRCs overlap, relying parties MUST execute the following steps to determine the correct trust anchor pool for a given verification time:
 
 1. From the set of all available TRCs for the ISD, filter out TRCs whose validity start time (`notBefore`) precedes the verification time.
 
@@ -979,6 +970,8 @@ To construct the trust anchor pool for a specific ISD at a given verification ti
 4. If the TRC is valid, add its root certificates to the trust anchor pool.
 
 5. If the TRC is in its grace period, add the preceding TRC's root certificates to the trust anchor pool.
+
+Note that any entity sending information secured by the Control Plane PKI, such as control plane messages, MUST be able to provide all the necessary trust material including certificates to verify said information. If any cryptographic material is missing in the process, the relying party MUST query the originator of the message for the missing material through the control plane API described in {{I-D.dekater-scion-controlplane}}, section "Distribution of Cryptographic Material". If it cannot be resolved, the verification process fails. For more details, see 4.2 "Signing and Verifying Control Plane Messages" [](#signing-verifying-cp-messages).
 
 ## TRC Updates {#update}
 

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -860,11 +860,11 @@ The certification path of a Control Plane AS certificate starts in a Control Pla
 
 To validate a certification path, a relying party builds a collection of root certificates know as the trust anchor pool. Because TRC updates can introduce a grace period where multiple TRCs overlap, relying parties MUST execute the following steps to determine the correct trust anchor pool for a given verification time:
 
-1. From the set of all available TRCs for the ISD, filter out TRCs whose validity start time (`notBefore`) precedes the verification time.
+1. From the set of all available TRCs for the ISD, filter out TRCs whose validity start time (`notBefore` date) precedes the verification time.
 
 2. From the remaining TRCs, identify those with the highest base number, then select the TRC with the highest serial number.
 
-3. If the verification time is strictly greater than the Candidate TRC's `notAfter` date, it is no longer valid. There are no valid trust anchors at the verification time, and the process terminates.
+3. If the verification time is strictly greater than the TRC's `notAfter` date, it is no longer valid. There are no valid trust anchors at the verification time, and the process terminates.
 
 4. If the TRC is valid, add its root certificates to the trust anchor pool.
 

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -966,15 +966,15 @@ However, AS certificates and the corresponding issuing CA certificates are **not
 
 ### TRC Selection For Trust Anchor Pool {#trc-selection}
 
-The selection of the right set of TRCs to build the trust anchor pool depends on the time of verification. This is typically the current time when verifying control plane messages.
+The selection of the right set of TRCs to build the trust anchor pool depends on the time of verification. This is typically the current time when verifying control plane messages, but may be a historical point in time when auditing past signatures.
 
-To construct the trust anchor pool for a specific ISD at a given verification time, a relying party executes the following steps:
+To construct the trust anchor pool for a specific ISD at a given verification time, a relying party MUST execute the following steps:
 
-1. Filter TRCs whose validity start time (`notBefore`) precedes the verification time.
+1. From the set of all available TRCs for the ISD, filter out TRCs whose validity start time (`notBefore`) precedes the verification time.
 
-2. Filter TRCs with the highest base number, then select the TRC with the highest serial number.
+2. From the remaining TRCs, identify those with the highest base number, then select the TRC with the highest serial number.
 
-3. If the TRC is not valid anymore (the verification time is greater than the TRC's `notAfter` date), there are no valid trust anchors at the verification time.
+3. If the verification time is strictly greater than the Candidate TRC's `notAfter` date, it is no longer valid. There are no valid trust anchors at the verification time, and the process terminates.
 
 4. If the TRC is valid, add its root certificates to the trust anchor pool.
 


### PR DESCRIPTION
Resolves #128

-  [x] Evaluate if we can remove sub-heading [3.4.1. ](https://scionassociation.github.io/scion-cppki_I-D/asn-1/draft-dekater-scion-pki.html#section-3.4.1)[TRC Selection For Trust Anchor Pool](https://scionassociation.github.io/scion-cppki_I-D/asn-1/draft-dekater-scion-pki.html#name-trc-selection-for-trust-anc), maybe this can just be a single paragraph

Diff [with main](https://author-tools.ietf.org/api/iddiff?url_1=https://scionassociation.github.io/scion-cppki_I-D/draft-dekater-scion-pki.txt&url_2=https://scionassociation.github.io/scion-cppki_I-D/trc_selection/draft-dekater-scion-pki.txt)