### PR TITLE
ASN1 - lower max size for sequences

### DIFF
--- a/asn1/trc.asn1
+++ b/asn1/trc.asn1
@@ -29,13 +29,13 @@ TRCPayload ::= SEQUENCE {
     validity              TRCValidity,
     gracePeriod           INTEGER,
     noTrustReset          BOOLEAN,
-    votes                 SEQUENCE SIZE (0..2047) OF INTEGER (0..4095),
-    votingQuorum          INTEGER (1..2047),
+    votes                 SEQUENCE SIZE (0..511) OF INTEGER (0..1023),
+    votingQuorum          INTEGER (1..1023),
     coreASes              SEQUENCE OF ASN,
     authoritativeASes     SEQUENCE OF ASN,
     description           UTF8String (SIZE (1..8192)) OPTIONAL,
-    certificates          SEQUENCE SIZE (1..4095) OF Certificate,
-    localizedDescriptions [0] SEQUENCE SIZE (1..MAX) OF LocalizedText OPTIONAL,
+    certificates          SEQUENCE SIZE (1..1023) OF Certificate,
+    localizedDescriptions [0] SEQUENCE SIZE (1..128) OF LocalizedText OPTIONAL,
     descriptionLanguage   [1] PrintableString OPTIONAL
 }
 

--- a/asn1/trc.asn1
+++ b/asn1/trc.asn1
@@ -29,13 +29,13 @@ TRCPayload ::= SEQUENCE {
     validity              TRCValidity,
     gracePeriod           INTEGER,
     noTrustReset          BOOLEAN,
-    votes                 SEQUENCE SIZE (0..511) OF INTEGER (0..1023),
-    votingQuorum          INTEGER (1..1023),
+    votes                 SEQUENCE SIZE (0..2047) OF INTEGER (0..4095),
+    votingQuorum          INTEGER (1..2047),
     coreASes              SEQUENCE OF ASN,
     authoritativeASes     SEQUENCE OF ASN,
     description           UTF8String (SIZE (1..8192)) OPTIONAL,
-    certificates          SEQUENCE SIZE (1..1023) OF Certificate,
-    localizedDescriptions [0] SEQUENCE SIZE (1..128) OF LocalizedText OPTIONAL,
+    certificates          SEQUENCE SIZE (1..4095) OF Certificate,
+    localizedDescriptions [0] SEQUENCE SIZE (1..1024) OF LocalizedText OPTIONAL,
     descriptionLanguage   [1] PrintableString (SIZE (1..64)) OPTIONAL
 }
 

--- a/asn1/trc.asn1
+++ b/asn1/trc.asn1
@@ -20,7 +20,7 @@ TRCValidity ::= SEQUENCE {
 }
 
 LocalizedText ::= SEQUENCE {
-    language        PrintableString,
+    language        PrintableString (SIZE (1..64)),
     content         UTF8String (SIZE (1..8192))
 }
 TRCPayload ::= SEQUENCE {
@@ -36,7 +36,7 @@ TRCPayload ::= SEQUENCE {
     description           UTF8String (SIZE (1..8192)) OPTIONAL,
     certificates          SEQUENCE SIZE (1..1023) OF Certificate,
     localizedDescriptions [0] SEQUENCE SIZE (1..128) OF LocalizedText OPTIONAL,
-    descriptionLanguage   [1] PrintableString OPTIONAL
+    descriptionLanguage   [1] PrintableString (SIZE (1..64)) OPTIONAL
 }
 
 TRCFormatVersion ::= INTEGER { v1(0) }
@@ -49,6 +49,6 @@ TRCID ::= SEQUENCE {
 
 ISD ::= INTEGER (1..65535)
 
-ASN ::= PrintableString
+ASN ::= PrintableString (SIZE (1..16))
 
 END

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -1324,7 +1324,7 @@ Changes made to drafts since ISE submission. This section is to be removed befor
 - Draftforge review
 - remove trust Hierarchy subsection and redundant code block
 - Certificate validity recommendations: align to current practice
-- TRC: introduce introduce language tags ({{BCP47}}) and localizedDescriptions, introduce more sequence limits in ASN.1 and recommend maximum size
+- TRC: introduce introduce language tags ({{BCP47}}) and localizedDescriptions, introduce more sequence limits in ASN.1 and recommend maximum size.
 - `authorityKeyIdentifier` Extension: clarify support for `authorityCertIssuer` and `authorityCertSerialNumber` attributes
 
 ## draft-dekater-scion-pki-12

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -1182,7 +1182,7 @@ TRCValidity ::= SEQUENCE {
 }
 
 LocalizedText ::= SEQUENCE {
-    language        PrintableString,
+    language        PrintableString (SIZE (1..64)),
     content         UTF8String (SIZE (1..8192))
 }
 TRCPayload ::= SEQUENCE {
@@ -1197,8 +1197,8 @@ TRCPayload ::= SEQUENCE {
     authoritativeASes     SEQUENCE OF ASN,
     description           UTF8String (SIZE (1..8192)) OPTIONAL,
     certificates          SEQUENCE SIZE (1..4095) OF Certificate,
-    localizedDescriptions [0] SEQUENCE SIZE (1..MAX) OF LocalizedText OPTIONAL,
-    descriptionLanguage   [1] PrintableString OPTIONAL
+    localizedDescriptions [0] SEQUENCE SIZE (1..1024) OF LocalizedText OPTIONAL,
+    descriptionLanguage   [1] PrintableString (SIZE (1..64)) OPTIONAL
 }
 
 TRCFormatVersion ::= INTEGER { v1(0) }
@@ -1211,7 +1211,7 @@ TRCID ::= SEQUENCE {
 
 ISD ::= INTEGER (1..65535)
 
-ASN ::= PrintableString
+ASN ::= PrintableString (SIZE (1..16))
 
 END
 ~~~~

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -638,6 +638,7 @@ A TRC can have the following states:
 ## TRC Fields {#trcfields}
 
 The TRC holds the root and voting certificates of the ISD, defining the ISD's trust policy. Its ASN.1 module is described in [](#trc-asn1).
+Although the ASN.1 schema permits larger structures, the total TRC size SHOULD NOT exceed 4 MB.
 Its fields are contained in a `TRCPayload` sequence. This section describes their syntax and semantics.
 
 ### `version`
@@ -1323,7 +1324,7 @@ Changes made to drafts since ISE submission. This section is to be removed befor
 - Draftforge review
 - remove trust Hierarchy subsection and redundant code block
 - Certificate validity recommendations: align to current practice
-- TRC: introduce introduce language tags ({{BCP47}}) and localizedDescriptions
+- TRC: introduce introduce language tags ({{BCP47}}) and localizedDescriptions, introduce more sequence limits in ASN.1 and recommend maximum size
 - `authorityKeyIdentifier` Extension: clarify support for `authorityCertIssuer` and `authorityCertSerialNumber` attributes
 
 ## draft-dekater-scion-pki-12


### PR DESCRIPTION
To avoid infinite size TRCs

Hi @oncilla , @tzaeschke is suggesting that we introduce stricter upper bounds for sequence sizes, to prevent having unbounded bloated TRCs that could be a DoS attack vector. 

We currently have a potentially unlimited size:
- 4095 certificates (16MB assuming 4KB/certificate)
- For each description field, max 8192 
- MAX localizedDescriptions (ubounded sequence - infinite)
- coreASes - unlimited
- authoritativeASes - unlimited
- ASN - unlimited
- language / descriptionLanguage unlimited

Shall we reduce limits a bit?  Something like:
- 1023 total certificates (4MB) 
- 128 localizedDescriptions (sequence - 1MB)
- For each description field, max 8192 (same as before? - I don't think it makes a big difference)
- ASN - 16 bytes
This way a TRC will be around 5MB, except if some certs are super bloated..

Remaining problem: 
- coreASes & authoritativeASes  are still unlimited - the SCION limit is 2**48, which would result in a still gigantic TRC.. Do we want to introduce a cap here? Why, and to what? there are no other hard limits in the spec AFAIK
@oncilla 

TODO: 
- [x] copy changes into appendix before merging