### PR TITLE
Clarify role and processes for authoritative ASes

### DIFF
--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -948,7 +948,7 @@ This section details the procedures for deploying the CP-PKI and securing contro
 Base TRCs are trust anchors and thus axiomatically trusted. All ASes within an ISD MUST be pre-loaded with the currently valid base-version TRC of their own ISD. For all specifications regarding the creation and distribution of initial/base TRCs, see [](#trc-ceremony).
 
 
-### TRC Update Discovery
+### TRC Update Discovery {#trc-update-discovery}
 
 All non-base TRCs of an ISD are updates of the ISD's base TRC(s). The TRC update chain consists of regular and sensitive TRC updates. The specifications and rules that apply to updating a TRC are described in [](#update).
 
@@ -961,6 +961,8 @@ SCION provides the following mechanisms for discovering TRC updates and fulfilli
 - *Active Discovery*: A relying party can actively request any TRC —either a specific version or the latest available version— from the sender of the secured information at any time. The necessary query and response is described in {{I-D.dekater-scion-controlplane}}, section "Distribution of Cryptographic Material".
 
 Relying parties such as an AS Control Service require at least one valid TRC available and should therefore discover TRC updates within the grace period defined in the updated TRC. Additionally, any entity sending information that is secured by the Control Plane PKI MUST be able to provide all the necessary trust material to verify said information, ensuring that relying parties can discover TRC updates in a matter of minutes to hours.
+
+Once discovered, a relying party can obtain the latest TRC from one of the Authoritative ASes (see [](auth)).
 
 ## Signing and Verifying Control Plane Messages {#signing-verifying-cp-messages}
 

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -934,7 +934,7 @@ If one or more of the above checks gives a negative result, the updated TRC SHOU
 
 ## Initial TRC Signing Ceremony {#trc-ceremony}
 
-The very first base TRC of an ISD - called the initial TRC - is a special case of the base TRC. The initial TRC MUST be signed during a Signing Ceremony where all voting representatives of the initial TRC take part to sign the TRC and exchange their public keys. Following this, all entities within an ISD can obtain that TRC by means of a secure offline or online mechanism.
+The very first base TRC of an ISD - called the initial TRC - is a special case of the base TRC. The initial TRC MUST be signed during a Signing Ceremony where all voting representatives of the initial TRC take part to sign the TRC and exchange their public keys. Following this, all entities within an ISD can obtain the initial TRC by means of a secure offline or online mechanism.
 
 [](#initial-ceremony) describes a possible procedure for the Signing Ceremony of an ISD's initial TRC. Whilst it is up to the initial members of an ISD how to organize the Signing Ceremony, it recommended to implement a process in line with the ceremony described in the appendix.
 

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -726,9 +726,10 @@ To assign or revoke core status, the target AS number is added to or removed fro
 
 ### `authoritativeASes` {#auth}
 
-The `authoritativeASes` field contains a sequence listing the Authoritative AS numbers in the ISD. Authoritative ASes are those ASes in an ISD that always possess the latest TRCs for the ISD and initiate TRC update announcements.
+Authoritative ASes are those ASes in an ISD that always possess the latest TRCs for the ISD and therefore initiate TRC update announcements.
+Every Authoritative AS MUST be a Core AS (i.e., be listed in the `coreASes` field).
 
-Every Authoritative AS MUST be a Core AS (i.e., be listed in the `coreASes` field). The encoding and uniqueness requirements for this sequence are identical to those of the `coreASes` field.
+The `authoritativeASes` field contains a sequence listing the Authoritative AS numbers in the ISD. The encoding and uniqueness requirements for this sequence are identical to those of the `coreASes` field.
 
 As with Core ASes, assigning or revoking Authoritative status is performed by adding or removing the target AS number from this sequence. For such modification, a sensitive TRC update is REQUIRED.
 
@@ -1035,6 +1036,8 @@ The Control Plane PKI relies on short-lived certificates as an alternative to re
 It is therefore recommended to deploy multiple, independent CAs within an ISD that can issue certificates to all member ASes and sustain the appropriate certificate renewal load. ASes should then be able to quickly switch over to a backup CA to renew their certificates in time.
 
 Furthermore, PKI operators need to ensure that the CAs maintain time synchronization with other system components. Further considerations related to this aspect are discussed in {{I-D.dekater-scion-controlplane}}, sections "Effects of Clock Inaccuracy" and "Attacks on Time Sources".
+
+It is also recommended to have multiple Authoritative ASes in an ISD (see [](#auth)).
 
 ## Operational Processes for ISD Governance
 

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -727,6 +727,7 @@ To assign or revoke core status, the target AS number is added to or removed fro
 ### `authoritativeASes` {#auth}
 
 Authoritative ASes are those ASes in an ISD that always possess the latest TRCs for the ISD and therefore initiate TRC update announcements.
+They are provisioned with the latest TRC by Voters following an update (see [](#trc-update-general)).
 Every Authoritative AS MUST be a Core AS (i.e., be listed in the `coreASes` field).
 
 The `authoritativeASes` field contains a sequence listing the Authoritative AS numbers in the ISD. The encoding and uniqueness requirements for this sequence are identical to those of the `coreASes` field.
@@ -870,7 +871,7 @@ The sections that follow provide more detailed descriptions of each rule.
 {: #table-8 title="Overview of the update types and corresponding rules"}
 
 
-### General Update Rules
+### General Update Rules {#trc-update-general}
 
 The following rules hold for each updated TRC, independent of the update type:
 
@@ -879,7 +880,7 @@ The following rules hold for each updated TRC, independent of the update type:
 - The `noTrustReset` field MUST NOT change (see also [](#notrustreset)).
 - The `votes` sequence of the updated TRC MUST only contain indices that refer to sensitive or regular voting certificates in the predecessor TRC. This guarantees that the updated TRC only contains valid votes authenticated by sensitive or regular voting certificates in the predecessor TRC. For more information, see [](#votes) and [](#cert).
 - The number of votes in the updated TRC MUST be greater than or equal to the number set in the `votingQuorum` field of the predecessor TRC (see [](#quorum)). The number of votes corresponds to the number of indices in the `votes` field of the updated TRC.
-- Voting ASes SHOULD distribute the updated TRC to all authoritative ASes within the ISD. The distribution mechanism is typically out of band and it is outside of the scope of this document.
+- Voting ASes SHOULD distribute the updated TRC to all Authoritative ASes within the ISD. The distribution mechanism is typically out of band and it is outside of the scope of this document.
 
 Discovery mechanisms for new TRCs are described in [](#trc-update-discovery).
 
@@ -964,7 +965,7 @@ SCION provides the following mechanisms for discovering TRC updates and fulfilli
 
 Relying parties such as an AS Control Service require at least one valid TRC available and should therefore discover TRC updates within the grace period defined in the updated TRC. Additionally, any entity sending information that is secured by the Control Plane PKI MUST be able to provide all the necessary trust material to verify said information, ensuring that relying parties can discover TRC updates in a matter of minutes to hours.
 
-Once discovered, a relying party can obtain the latest TRC from one of the Authoritative ASes (see [](auth)).
+Once it discovers a new TRC, a relying party can obtain the TRC from one of the Authoritative ASes (see [](#auth)).
 
 ## Signing and Verifying Control Plane Messages {#signing-verifying-cp-messages}
 
@@ -1037,7 +1038,8 @@ It is therefore recommended to deploy multiple, independent CAs within an ISD th
 
 Furthermore, PKI operators need to ensure that the CAs maintain time synchronization with other system components. Further considerations related to this aspect are discussed in {{I-D.dekater-scion-controlplane}}, sections "Effects of Clock Inaccuracy" and "Attacks on Time Sources".
 
-It is also recommended to have multiple Authoritative ASes in an ISD (see [](#auth)).
+To ensure redundancy, an ISD should contain multiple Authoritative ASes (see [](#auth)). However, the total number of Authoritative ASes should be kept relatively low since Voters need to provision each Authoritative AS with the latest TRC following each update (see [](#trc-update-general)).
+
 
 ## Operational Processes for ISD Governance
 

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -880,6 +880,7 @@ The following rules hold for each updated TRC, independent of the update type:
 - The number of votes in the updated TRC MUST be greater than or equal to the number set in the `votingQuorum` field of the predecessor TRC (see [](#quorum)). The number of votes corresponds to the number of indices in the `votes` field of the updated TRC.
 - Voting ASes SHOULD distribute the updated TRC to all authoritative ASes within the ISD. The distribution mechanism is typically out of band and it is outside of the scope of this document.
 
+Discovery mechanisms for new TRCs are described in [](#trc-update-discovery).
 
 ### Regular TRC Update
 

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -1038,7 +1038,7 @@ It is therefore recommended to deploy multiple, independent CAs within an ISD th
 
 Furthermore, PKI operators need to ensure that the CAs maintain time synchronization with other system components. Further considerations related to this aspect are discussed in {{I-D.dekater-scion-controlplane}}, sections "Effects of Clock Inaccuracy" and "Attacks on Time Sources".
 
-To ensure redundancy, an ISD should contain multiple Authoritative ASes (see [](#auth)). However, the total number of Authoritative ASes should be kept relatively low since Voters need to provision each Authoritative AS with the latest TRC following each update (see [](#trc-update-general)).
+To ensure redundancy, an ISD should contain multiple Authoritative ASes (see [](#auth)).
 
 
 ## Operational Processes for ISD Governance

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -934,7 +934,7 @@ If one or more of the above checks gives a negative result, the updated TRC SHOU
 
 ## Initial TRC Signing Ceremony {#trc-ceremony}
 
-The very first base TRC of an ISD - called the initial TRC - is a special case of the base TRC. The initial TRC MUST be signed during a Signing Ceremony where all voting representatives of the initial TRC take part to sign the TRC and exchange their public keys. Following this, all entities within an ISD can obtain the TRC by means of a secure offline or online mechanism.
+The very first base TRC of an ISD - called the initial TRC - is a special case of the base TRC. The initial TRC MUST be signed during a Signing Ceremony where all voting representatives of the initial TRC take part to sign the TRC and exchange their public keys. Following this, all entities within an ISD can obtain that TRC by means of a secure offline or online mechanism.
 
 [](#initial-ceremony) describes a possible procedure for the Signing Ceremony of an ISD's initial TRC. Whilst it is up to the initial members of an ISD how to organize the Signing Ceremony, it recommended to implement a process in line with the ceremony described in the appendix.
 

--- a/draft-dekater-scion-pki.md
+++ b/draft-dekater-scion-pki.md
@@ -965,7 +965,7 @@ SCION provides the following mechanisms for discovering TRC updates and fulfilli
 
 Relying parties such as an AS Control Service require at least one valid TRC available and should therefore discover TRC updates within the grace period defined in the updated TRC. Additionally, any entity sending information that is secured by the Control Plane PKI MUST be able to provide all the necessary trust material to verify said information, ensuring that relying parties can discover TRC updates in a matter of minutes to hours.
 
-Once it discovers a new TRC, a relying party can obtain the TRC from one of the Authoritative ASes (see [](#auth)).
+Once a relying party learns of a new TRC, it can obtain the TRC from one of the Authoritative ASes (see [](#auth)).
 
 ## Signing and Verifying Control Plane Messages {#signing-verifying-cp-messages}
 


### PR DESCRIPTION
Resolves #155 

[Diff with main](https://author-tools.ietf.org/api/iddiff?url_1=https://scionassociation.github.io/scion-cppki_I-D/draft-dekater-scion-pki.txt&url_2=https://scionassociation.github.io/scion-cppki_I-D/authoritative_as_clarifications/draft-dekater-scion-pki.txt)